### PR TITLE
Added a config for host + fix config not loaded for single files

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,6 +138,11 @@
 					"default": "",
 					"markdownDescription": "Absolute path to php.ini file. `string`"
 				},
+				"fiveServer.host": {
+					"type": "string",
+					"default": "0.0.0.0",
+					"markdownDescription": "Set the server host. `string`"
+				},
 				"fiveServer.port": {
 					"type": "number",
 					"default": 5555,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -348,6 +348,8 @@ export function activate(context: vscode.ExtensionContext) {
 
       // start a simple server
       await fiveServer.start({
+        ...config,
+        injectBody: shouldInjectBody(),
         root,
         open: file,
       });

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -33,7 +33,8 @@ export const assignVSCodeConfiguration = () => {
   const navigate = <boolean>getConfig("navigate");
   const php = <string>getConfig("php.executable");
   const phpIni = <string>getConfig("php.ini");
+  const host = <string>getConfig("host");
   const port = <number>getConfig("port");
 
-  return { browser, ignore, navigate, php, phpIni, port };
+  return { browser, ignore, navigate, php, phpIni, host, port };
 };


### PR DESCRIPTION
Regarding https://github.com/yandeu/five-server/issues/61, I'm adding a way to specify a hostname to the extension.

Also, it didn't loaded the config if it was a single file started in five server, made it load options as well