### PR TITLE
Add support to set a base URL to allow proxying

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2225,7 +2225,8 @@
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "hasInstallScript": true,
       "os": [
-        "darwin"
+        "darwin",
+        "linux"
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"

--- a/package.json
+++ b/package.json
@@ -151,6 +151,11 @@
           "default": "",
           "markdownDescription": "Absolute path to php.ini file. `string`"
         },
+        "fiveServer.serverRoot": {
+          "type": "string",
+          "default": "AUTO",
+          "markdownDescription": "Manually set the server root. (Useful if the server is behind a reverse proxy) `string`\n\r*Server root is automatically set to be blank if running on desktop and \"/proxy/{PORT}/\" if on web*"
+        },
         "fiveServer.host": {
           "type": "string",
           "default": "0.0.0.0",

--- a/package.json
+++ b/package.json
@@ -151,10 +151,10 @@
           "default": "",
           "markdownDescription": "Absolute path to php.ini file. `string`"
         },
-        "fiveServer.serverRoot": {
+        "fiveServer.baseURL": {
           "type": "string",
-          "default": "AUTO",
-          "markdownDescription": "Manually set the server root. (Useful if the server is behind a reverse proxy) `string`\n\r*Server root is automatically set to be blank if running on desktop and \"/proxy/{PORT}/\" if on web*"
+          "default": "/",
+          "markdownDescription": "Manually set the baseURL of the server. (Useful if the server is behind a reverse proxy) `string`\n\r*If set to 'AUTO' server root will automatically be set to \"/\" if running on desktop and \"/proxy/{PORT}/\" if on web*"
         },
         "fiveServer.host": {
           "type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,7 +20,7 @@ let pty: PTY;
 let activeFileName = "";
 let root: string = "";
 let _root: string | null = null;
-let serverRoot: string = "ERROR";
+let baseURL: string = "ERROR";
 let workspace: string | undefined;
 let rootAbsolute: string;
 let config: LiveServerParams = {};
@@ -112,12 +112,12 @@ const shouldInjectBody = () => {
   return false;
 };
 
-function guessServerRoot() {
-  // Auto set serverRoot based on appHost
-  if (config.serverRoot === "AUTO") {
-    serverRoot = "/";
+function autoSetBaseURL() {
+  // Auto set baseURL based on appHost
+  if (config.baseURL === "AUTO") {
+    baseURL = "/";
     if (vscode.env.appHost !== "desktop")
-      serverRoot = "/proxy/" + config.port ?? "5500" + "/";
+      baseURL = "/proxy/" + config.port ?? "5500" + "/";
   }
 }
 
@@ -278,7 +278,7 @@ export function activate(context: vscode.ExtensionContext) {
       // get configFile for "root, injectBody and highlight"
       config = { ...config, ...(await getConfigFile(true, workspace)) };
 
-      guessServerRoot();
+      autoSetBaseURL();
 
       if (_root) root = _root;
       else if (config && config.root) root = config.root;
@@ -315,7 +315,7 @@ export function activate(context: vscode.ExtensionContext) {
           injectBody: shouldInjectBody(),
           open: config.open !== undefined ? config.open : file,
           root,
-          serverRoot,
+          baseURL,
           workspace,
           _cli: true,
         });
@@ -335,7 +335,7 @@ export function activate(context: vscode.ExtensionContext) {
           injectBody: shouldInjectBody(),
           open: config.open !== undefined ? config.open : file,
           root,
-          serverRoot,
+          baseURL,
           workspace,
           _cli: true,
         });
@@ -362,14 +362,14 @@ export function activate(context: vscode.ExtensionContext) {
       const file = basename(fileName);
       const root = fileName.replace(file, "");
 
-      guessServerRoot();
+      autoSetBaseURL();
 
       // start a simple server
       await fiveServer.start({
         ...config,
         injectBody: shouldInjectBody(),
         root,
-        serverRoot,
+        baseURL,
         open: file,
       });
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,7 +20,7 @@ let pty: PTY;
 let activeFileName = "";
 let root: string = "";
 let _root: string | null = null;
-let baseURL: string = "ERROR";
+let baseURL: string = "NULL";
 let workspace: string | undefined;
 let rootAbsolute: string;
 let config: LiveServerParams = {};
@@ -114,11 +114,17 @@ const shouldInjectBody = () => {
 
 function autoSetBaseURL() {
   // Auto set baseURL based on appHost
-  if (config.baseURL === "AUTO") {
-    baseURL = "/";
-    if (vscode.env.appHost !== "desktop")
-      baseURL = "/proxy/" + config.port ?? "5500" + "/";
+  if (config.baseURL !== "AUTO") {
+    if (config.baseURL) baseURL = config.baseURL;
+    return;
   }
+
+  if (vscode.env.appHost !== "desktop") {
+    baseURL = "/proxy/" + config.port ?? "5500" + "/";
+    return;
+  }
+
+  baseURL = "/";
 }
 
 export function activate(context: vscode.ExtensionContext) {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -33,7 +33,7 @@ export const assignVSCodeConfiguration = () => {
   const navigate = <boolean>getConfig("navigate");
   const php = <string>getConfig("php.executable");
   const phpIni = <string>getConfig("php.ini");
-  const serverRoot = <string>getConfig("serverRoot");
+  const baseURL = <string>getConfig("baseURL");
   const host = <string>getConfig("host");
   const port = <number>getConfig("port");
   const injectBody = <boolean>getConfig("injectBody");
@@ -45,7 +45,7 @@ export const assignVSCodeConfiguration = () => {
     navigate,
     php,
     phpIni,
-    serverRoot,
+    baseURL,
     host,
     port,
     injectBody,

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -33,6 +33,7 @@ export const assignVSCodeConfiguration = () => {
   const navigate = <boolean>getConfig("navigate");
   const php = <string>getConfig("php.executable");
   const phpIni = <string>getConfig("php.ini");
+  const serverRoot = <string>getConfig("serverRoot");
   const host = <string>getConfig("host");
   const port = <number>getConfig("port");
   const injectBody = <boolean>getConfig("injectBody");
@@ -44,6 +45,7 @@ export const assignVSCodeConfiguration = () => {
     navigate,
     php,
     phpIni,
+    serverRoot,
     host,
     port,
     injectBody,

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -38,7 +38,7 @@ async function main() {
       {
         encoding: "utf-8",
         stdio: "inherit",
-      }
+      },
     );
 
     // Run the extension test


### PR DESCRIPTION
Provides the option added in [yandeu/five-server#125](https://github.com/yandeu/five-server/pull/125) and an option to autoconfig for VSCode for Web. 